### PR TITLE
コンテナ内でdbを作成できるようにした

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.webpacker.check_yarn_integrity = false
 end


### PR DESCRIPTION
ローカル環境時、コンテナ内でrails db:createを用いた際に
```
yarn: error: no such option: --integrity

  Your Yarn packages are out of date!
  Please run `yarn install --check-files` to update.

To disable this check, please change `check_yarn_integrity`
to `false` in your webpacker config file (config/webpacker.yml).
```
といったエラーが発生したので
解消しdbを作成できるようにしました。